### PR TITLE
Update stylesheets/application.css

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -91,8 +91,6 @@ h1 {
 	font-family: 'Korolev', sans-serif;
 	margin: 15px 24px;
 	padding: 0;
-	width: 400px;
-	float: left;
 }
 h2, h3, h4, .wiki h1, .wiki h2, .wiki h3 { border-bottom: 0px;}
 


### PR DESCRIPTION
Removed float: left and width: 400px from h1 definition. This fixed width causes formatting errors in wiki articles and does not appear to be utilized on any other screen.
See issue #1.
