### PR TITLE
Fixed main menu @ Redmine 2.3.0 stable

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -136,6 +136,7 @@ h1, h2, h3 { color: #333; }
 	float: left;
 	width: 850px;
 	position: relative;
+	clear: both;
 }
 #main-menu li a { font-weight: normal; padding: 6px 8px 8px; color: #888; }
 #main-menu li a:hover { 


### PR DESCRIPTION
Hi, I've just installed your gitlab theme @ Redmine 2.3.0-stable and I've found a problem of the position of main menu.

![before](https://f.cloud.github.com/assets/212607/371126/6d75a4a4-a31a-11e2-951e-8a18c26d8e11.png)

I've fixed this problem and here is the result.

![after](https://f.cloud.github.com/assets/212607/371127/929bb642-a31a-11e2-8eda-4fc03c717328.png)

Could you please merge this ?
